### PR TITLE
Added pathPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ plugins:[
             shortName: 'Gridsome',
             themeColor: '#666600',
             backgroundColor: '#ffffff',
-            icon: '', // must be provided
+            icon: '', // must be provided like 'src/favicon.png'
             msTileImage: '',
             msTileColor: '#666600'
         }

--- a/src/files/service-worker.js
+++ b/src/files/service-worker.js
@@ -13,6 +13,7 @@ export const createServiceWorker = async (context, config, queue, options) => {
     const serviceWorkerPath = path.join(config.outputDir, options.serviceWorkerPath)
   
     await generateSW({
+      modifyURLPrefix: { '' : config.pathPrefix + '/' || ''},
       swDest: serviceWorkerPath,
       globDirectory: config.outputDir,
       globPatterns: [`**\/*.{${options.cachedFileTypes}}`, "**\/*.json"],

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,13 @@ function Plugin (api, options) {
     await createServiceWorker(context, config, queue, options);
     log('..done\n');
   })
+
+  const pathPrefix = api._app.config.pathPrefix ? api._app.config.pathPrefix + '/' : '/';
+
   api.setClientOptions({
     title: options.title,
-    serviceWorkerPath: path.join('/', options.serviceWorkerPath),
-    manifestPath: path.join('/', options.manifestPath),
+    serviceWorkerPath: path.join(pathPrefix, options.serviceWorkerPath),
+    manifestPath: path.join(pathPrefix, options.manifestPath),
     statusBarStyle: options.statusBarStyle,
     themeColor: options.themeColor
   })


### PR DESCRIPTION
See https://github.com/rishabh3112/gridsome-plugin-pwa/issues/17 for more info.

However, just to make it clear. The changed part in `src/index.js` is quite ugly and I'm currently not sure how to get the config file else. Two other options that I have in mind, is to import the config file from the user's `gridsome.config.js` file or to force to duplicate the value in the plugins' option.

Maybe there is even a better way.

But what it does is it checks if there is a pathPrefix if so, we just add it to the server-worker and manifest.json file. 

We are looking for three steps that needed to be changed:

1. the `manifest.json` file needs to be pushed with the pathPrefix
2. In the `dist/assets/js/app.<hash>.js` needs to be checked that the path of the service-worker is set correctly
3. And in the `servier-worker.js` file we need to check that the precacheManifest URLs are set correclty as well

Ah and I had to change something in the readme file, because the icon part was not clear for me in the beginning and wasted some time 🙈