### PR TITLE
Change outputDir to outDir to match Gridsome config var name.

### DIFF
--- a/src/files/manifest.js
+++ b/src/files/manifest.js
@@ -3,16 +3,16 @@ import sizeOf from 'image-size'
 import fs from 'fs-extra'
 
 export const createManifest = async (context, config, queue, options) => {
-    const manifestDest = path.join(config.outputDir, options.manifestPath)
-    const iconsDir = path.join(config.outputDir, 'assets/static/');
+    const manifestDest = path.join(config.outDir, options.manifestPath)
+    const iconsDir = path.join(config.outDir, 'assets/static/');
     const iconName = options.icon.split('/').slice(-1)[0];
     // Copy Favicon from options.icon to assets/static
     fs.copyFileSync(path.resolve(context, options.icon), path.join(iconsDir, iconName));
 
     //TODO: generate all size images from options.icon
-    const iconsNames = [path.relative(config.outputDir, path.join(iconsDir, iconName))]
+    const iconsNames = [path.relative(config.outDir, path.join(iconsDir, iconName))]
     const icons = iconsNames.map((icon) => {
-        let iconData =  sizeOf(path.resolve(config.outputDir, icon));
+        let iconData =  sizeOf(path.resolve(config.outDir, icon));
         iconData.src = icon;
         return iconData;
     });

--- a/src/files/service-worker.js
+++ b/src/files/service-worker.js
@@ -5,21 +5,21 @@ import fs from 'fs-extra'
 const appendToServiceWorker = async (config, options) => {
     const skipWaitingPath = path.resolve(__dirname, '../utils/skip-wating.js')
     const skipWaiting = await fs.readFile(skipWaitingPath, 'utf8')
-    const outPath = path.join(config.outputDir, options.serviceWorkerPath);
+    const outPath = path.join(config.outDir, options.serviceWorkerPath);
     await fs.writeFile(outPath, `\n${skipWaiting}`, { flag: 'a' })
 }
 
 export const createServiceWorker = async (context, config, queue, options) => {
-    const serviceWorkerPath = path.join(config.outputDir, options.serviceWorkerPath)
+    const serviceWorkerPath = path.join(config.outDir, options.serviceWorkerPath)
   
     await generateSW({
       swDest: serviceWorkerPath,
-      globDirectory: config.outputDir,
+      globDirectory: config.outDir,
       globPatterns: [`**\/*.{${options.cachedFileTypes}}`, "**\/*.json"],
       globIgnores: [options.serviceWorkerPath, '**\/*client.json', '**\/*server.json'],
       templatedUrls: queue.reduce((urls, page) => {
         const url = page.path.substring(1)
-        const file = path.relative(config.outputDir, page.htmlOutput)
+        const file = path.relative(config.outDir, page.htmlOutput)
         if (url) urls[url] = file
         return urls
       }, {})


### PR DESCRIPTION
Re: https://github.com/rishabh3112/gridsome-plugin-pwa/issues/19

Update the Gridsome config variable name used for the output directory to 'outDir' instead of 'outputDir'.