### PR TITLE
fix parameter name

### DIFF
--- a/src/files/service-worker.js
+++ b/src/files/service-worker.js
@@ -19,10 +19,10 @@ export const createServiceWorker = async (context, config, queue, options) => {
       globDirectory: config.outputDir,
       globPatterns: [`**\/*.{${options.cachedFileTypes}}`, "**\/*.json"],
       globIgnores: [options.serviceWorkerPath, '**\/*client.json', '**\/*server.json'],
-      templatedUrls: queue.reduce((urls, page) => {
+      templatedURLs: queue.reduce((urls, page) => {
         const url = page.path.substring(1)
         const file = path.relative(config.outputDir, page.htmlOutput)
-        // Don't add url to templatedUrls if it has dynamic routes #29
+        // Don't add url to templatedURLs if it has dynamic routes #29
         if (url && url.indexOf('/:') === -1) urls[url] = file
         return urls
       }, {})


### PR DESCRIPTION
When I run a gridsome build on Mac, I get:
```
- service-worker.js..ValidationError: "templatedUrls" is not a supported parameter.
    at Object.exports.process (/path/to/gridsome_project/node_modules/@hapi/joi/lib/errors.js:202:19)
    at internals.Object._validateWithOptions (/path/to/gridsome_project/node_modules/@hapi/joi/lib/types/any/index.js:763:31)
    at internals.Object.validate (/path/to/gridsome_project/node_modules/@hapi/joi/lib/types/any/index.js:797:21)
    at module.exports (/path/to/gridsome_project/node_modules/workbox-build/build/lib/validate-options.js:14:14)
    at generateSW (/path/to/gridsome_project/node_modules/workbox-build/build/generate-sw.js:202:19)
    at createServiceWorker (/path/to/gridsome_project/node_modules/gridsome-plugin-pwa/files/service-worker.js:33:38)
    at Plugin.api.afterBuild (/path/to/gridsome_project/node_modules/gridsome-plugin-pwa/index.js:26:67)
```
The correct parameter name for workbox is "templatedURLs", not "templatedUrls".