### PR TITLE
Fix path generation for msapplication-TileImage

### DIFF
--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -1,3 +1,4 @@
+const { parse } = require('path');
 const { register } = require('register-service-worker');
 
 const clientConfig = function (Vue, options, context) {
@@ -30,8 +31,8 @@ const clientConfig = function (Vue, options, context) {
   }
 
   const iconsDir = 'assets/static/';
-  const iconName = options.icon.split('/').slice(-1)[0];
-  const msTileImage = `/${iconsDir}${iconName}-144x144.png`;
+  const iconPathParsed = parse(options.icon);
+  const msTileImage = `/${iconsDir}${iconPathParsed.name}-144x144${iconPathParsed.ext}`;
 
   head.link.push({
     rel: 'manifest',


### PR DESCRIPTION
Fixes rishabh3112/gridsome-plugin-pwa#48

The path for msapplication-TileImage was put together the wrong way:

`favicon.png-144x144.png` instead of `favicon-144x144.png`.

This commit corrects the behaviour.