### PR TITLE
Issue 55/separate maskable icon file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,18 @@ plugins:[
             statusBarStyle: 'default',
             themeColor: '#666600',
             backgroundColor: '#ffffff',
+
+            // icon should be a path to the static folder i.e. '/static/icon.png'
             icon: '',
+
+            // set {maskableIcon: true} to use the same icon (this will set
+            // {purpose:  'maskable any'}), or specify a different icon path
+            maskableIcon: true,                 // Optional
             shortName: 'Gridsome',              // Optional
             description: 'Gridsome is awesome!',// Optional
             categories: ['education'],          // Optional
             lang: 'en-GB',                      // Optional
             dir: 'auto',                        // Optional
-            maskableIcon: true,                 // Optional
             screenshots: [                      // Optional
                 {
                     src: 'src/screenshot1.png',

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ plugins:[
             themeColor: '#666600',
             backgroundColor: '#ffffff',
 
-            // icon should be a path to the static folder i.e. '/static/icon.png'
+            // icon should be a path to the static folder i.e. 'static/icon.png'
             icon: '',
 
             // set {maskableIcon: true} to use the same icon (this will set

--- a/src/files/manifest.js
+++ b/src/files/manifest.js
@@ -7,7 +7,7 @@ export const createManifest = async (context, config, queue, options) => {
     const manifestDest = path.join(config.outputDir, options.manifestPath);
     const iconsDir = path.join(config.outputDir, options.staticAssetsDir);
     const iconName = options.icon.split('/').slice(-1)[0];
-    const maskableIconName = typeof options.maskableIcon === 'string' 
+    let maskableIconName = typeof options.maskableIcon === 'string' 
         ? options.maskableIcon.split('/').slice(-1)[0] 
         : null
 
@@ -46,7 +46,7 @@ export const createManifest = async (context, config, queue, options) => {
 
             // add and process { maskableIcon }
             icons.push({src, type, sizes, purpose});
-            results.push(sharp(options.maskableIconName).resize(size, size).toFile(imagePath))
+            results.push(sharp(options.maskableIcon).resize(size, size).toFile(imagePath))
         }
 
         // always return a single promise

--- a/src/files/manifest.js
+++ b/src/files/manifest.js
@@ -27,8 +27,10 @@ export const createManifest = async (context, config, queue, options) => {
 
         // maskableIcon can now be boolean or an icon path. 
         // if it is true, or is the same icon file as standard icon, set 'maskable any' 
+        // also revert maskableIconName to null, as we won't need to process separately
         if (options.maskableIcon === true || options.maskableIcon === options.icon) {
             purpose = 'maskable any'
+            maskableIconName = null
         } 
 
         // add and process { icon }
@@ -36,7 +38,7 @@ export const createManifest = async (context, config, queue, options) => {
         const results = [sharp(options.icon).resize(size, size).toFile(imagePath)]
 
         // if maskableIcon is a string, then we need to process it as a separate maskable icon
-        if (options.maskableIcon && typeof options.maskableIcon === 'string') {
+        if (maskableIconName) {
             imagePath = path.join(iconsDir, rename(maskableIconName, { suffix: `-maskable-${sizes}` }))
             src = path.relative(config.outputDir, imagePath);
             type = 'image/' + maskableIconName.split('.').slice(-1)[0];

--- a/src/files/manifest.js
+++ b/src/files/manifest.js
@@ -32,18 +32,18 @@ export const createManifest = async (context, config, queue, options) => {
         } 
 
         // add and process { icon }
-        icons.push({src, type, sizes, purpose });
+        icons.push({src, type, sizes, purpose});
         const results = [sharp(options.icon).resize(size, size).toFile(imagePath)]
 
         // if maskableIcon is a string, then we need to process it as a separate maskable icon
         if (options.maskableIcon && typeof options.maskableIcon === 'string') {
             imagePath = path.join(iconsDir, rename(maskableIconName, { suffix: `-maskable-${sizes}` }))
             src = path.relative(config.outputDir, imagePath);
-            type = 'image/' + iconName.split('.').slice(-1)[0];
+            type = 'image/' + maskableIconName.split('.').slice(-1)[0];
             purpose = 'maskable'
 
             // add and process { maskableIcon }
-            icons.push({src, type, sizes, purpose });
+            icons.push({src, type, sizes, purpose});
             results.push(sharp(options.maskableIconName).resize(size, size).toFile(imagePath))
         }
 


### PR DESCRIPTION
Added ability to specify a separate 'maskable' icon. 

This allows developers to create a combination of PWA icons suitable for their applications:

- Single icon, generate as 'any'
- Single icon, generate as 'maskable any'
- Separate icons, generate one as 'any' and the other as 'maskable'

Tested locally using npm link and checked generated manifest.json using [manifest-validator](https://manifest-validator.appspot.com/). Scenarios tested:

`{ icon: 'static/icon.png' }`
Expected: Manifest contains array of 'any' icons.
Expected: dist/assets/static contains single set of icons.
Result: As expected

`{ icon: 'static/icon.png', maskableIcon: false }`
Expected: Manifest contains array of 'any' icons.
Expected: dist/assets/static contains single set of icons.
Result: As expected

`{ icon: 'static/icon.png', maskableIcon: true }`
Expected: Manifest contains array of 'maskable any' icons.
Expected: dist/assets/static contains single set of icons.
Result: As expected

`{ icon: 'static/icon.png', maskableIcon: 'static/icon.png' }`
Expected: Manifest contains array of 'maskable any' icons.
Expected: dist/assets/static contains single set of icons.
Result: As expected

`{ icon: 'static/icon.png', maskableIcon: 'static/icon-maskable.png' }`
Expected: Manifest contains array of 'any' and 'maskable' icons.
Expected: dist/assets/static contains two sets of icons (maskable, any).
Result: As expected