### PR TITLE
Add sizes=any to .ico icon

### DIFF
--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -54,6 +54,7 @@ const clientConfig = function (Vue, options, context) {
 
     head.link.push({
       rel: 'alternate icon',
+      sizes: 'any',
       href: 'favicon.ico',
     });
   }


### PR DESCRIPTION
Stops Chrome downloading and using the .ico and uses the .svg instead.

https://css-tricks.com/favicons-how-to-make-sure-browsers-only-download-the-svg-version/